### PR TITLE
fix: resolve image loading and admin logout issues

### DIFF
--- a/apps/web-astro/src/components/admin/ArticleEditorSidebar.tsx
+++ b/apps/web-astro/src/components/admin/ArticleEditorSidebar.tsx
@@ -18,7 +18,8 @@ function featuredImagePreviewUrl(fileId: string): string {
   const bucket = import.meta.env.PUBLIC_STORAGE_BUCKET_ID ?? "images";
   const project =
     import.meta.env.PUBLIC_APPWRITE_PROJECT_ID ?? "69e462f20036d39192ba";
-  return `${endpoint}/storage/buckets/${bucket}/files/${fileId}/preview?width=400&height=250&project=${project}`;
+  // Use /view instead of /preview to avoid 403 errors on plan limits
+  return `${endpoint}/storage/buckets/${bucket}/files/${fileId}/view?project=${project}`;
 }
 
 export default function ArticleEditorSidebar({

--- a/apps/web-astro/src/layouts/Admin.astro
+++ b/apps/web-astro/src/layouts/Admin.astro
@@ -73,6 +73,7 @@ const prefix = locale === "pt-br" ? "" : `/${locale}`;
 <script>
   document.getElementById("logout-btn")?.addEventListener("click", async () => {
     await fetch("/api/auth/logout", { method: "POST" });
-    window.location.href = "/admin/login";
+    // Redirect to homepage instead of admin login page
+    window.location.href = "/";
   });
 </script>

--- a/apps/web-astro/src/lib/__tests__/appwrite.test.ts
+++ b/apps/web-astro/src/lib/__tests__/appwrite.test.ts
@@ -85,16 +85,23 @@ describe("getImageUrl", () => {
     expect(mod.getImageUrl(url)).toBe(url);
   });
 
-  it("constructs preview URL for fileId", () => {
+  it("constructs view URL for fileId", () => {
     const result = mod.getImageUrl("file_789");
     expect(result).toBe(
-      "https://endpoint.example.com/storage/buckets/bucket_456/files/file_789/preview?width=800&height=600&project=proj_123"
+      "https://endpoint.example.com/storage/buckets/bucket_456/files/file_789/view?project=proj_123"
     );
   });
 
-  it("uses custom width and height when provided", () => {
+  it("includes project query param in view URL", () => {
+    const result = mod.getImageUrl("file_789");
+    expect(result).toContain("/view?");
+    expect(result).toContain("project=proj_123");
+  });
+
+  it("does not include width/height in view URL", () => {
     const result = mod.getImageUrl("file_789", 400, 300);
-    expect(result).toContain("width=400&height=300");
+    expect(result).not.toContain("width");
+    expect(result).not.toContain("height");
   });
 });
 

--- a/apps/web-astro/src/lib/appwrite.ts
+++ b/apps/web-astro/src/lib/appwrite.ts
@@ -121,7 +121,9 @@ export function getImageUrl(fileId: string, width = 800, height = 600): string {
   const endpoint = getEnv("APPWRITE_ENDPOINT");
   const project = getEnv("APPWRITE_PROJECT_ID");
   const bucket = getEnv("STORAGE_BUCKET_ID");
-  return `${endpoint}/storage/buckets/${bucket}/files/${fileId}/preview?width=${width}&height=${height}&project=${project}`;
+  // Use /view instead of /preview to avoid 403 errors on plan limits.
+  // Sizing is handled via CSS/Tailwind, not URL params.
+  return `${endpoint}/storage/buckets/${bucket}/files/${fileId}/view?project=${project}`;
 }
 
 export function setSessionCookie(

--- a/apps/web-astro/src/pages/api/upload.ts
+++ b/apps/web-astro/src/pages/api/upload.ts
@@ -27,7 +27,8 @@ export const POST: APIRoute = async ({ locals, request }) => {
     const buffer = Buffer.from(await file.arrayBuffer());
     const input = InputFile.fromBuffer(buffer, file.name || "upload.bin");
     const created = await storage.createFile(BUCKET, ID.unique(), input);
-    const url = `${getEnv("APPWRITE_ENDPOINT")}/storage/buckets/${BUCKET}/files/${created.$id}/preview?project=${getEnv("APPWRITE_PROJECT_ID")}`;
+    // Use /view instead of /preview to avoid 403 errors on plan limits
+    const url = `${getEnv("APPWRITE_ENDPOINT")}/storage/buckets/${BUCKET}/files/${created.$id}/view?project=${getEnv("APPWRITE_PROJECT_ID")}`;
     return json({ success: true, fileId: created.$id, url });
   } catch {
     return json({ error: "Falha ao enviar arquivo" }, 500);

--- a/apps/web-astro/tests/features/admin/auth.feature
+++ b/apps/web-astro/tests/features/admin/auth.feature
@@ -15,3 +15,10 @@ Feature: Admin Authentication
     Given the user navigates to "/admin/login"
     When they submit the login form with invalid credentials
     Then they should see a login error
+
+  @p1
+  Scenario: Admin logout redirects to homepage
+    Given the user is logged in as admin
+    When they click the logout button
+    Then they should be redirected to the homepage
+    And the page should show the homepage hero

--- a/apps/web-astro/tests/steps/admin.steps.ts
+++ b/apps/web-astro/tests/steps/admin.steps.ts
@@ -248,3 +248,23 @@ Then(
     await expect(page.locator("h1")).toContainText(title);
   }
 );
+
+When("they click the logout button", async ({ page }) => {
+  const logoutBtn = page.getByRole("button", { name: /sair/i });
+  await logoutBtn.click();
+  // Wait for the logout API call to complete and redirect
+  await page.waitForURL("/", { timeout: 10000 });
+});
+
+Then("they should be redirected to the homepage", async ({ page }) => {
+  expect(page.url()).toBe(
+    page.context().browser()?.contexts()[0]?.pages()[0]?.url() || ""
+  );
+  await expect(page).toHaveURL(/^\/$|^\/$/);
+});
+
+Then("the page should show the homepage hero", async ({ page }) => {
+  // The homepage should display the hero section with search or featured articles
+  const hero = page.locator("header, [data-testid='hero'], h1");
+  await expect(hero.first()).toBeVisible({ timeout: 10000 });
+});


### PR DESCRIPTION
## Summary

This PR fixes two UX bugs affecting article display and admin logout workflow:

1. **Article images not showing** — Switched from Appwrite `/preview` endpoint (blocked by plan limits) to `/view` endpoint
2. **Admin logout incorrect redirect** — Changed redirect from `/admin/login` to homepage `/`

## Changes

- Switch `getImageUrl()` to use `/view` endpoint (works without image transformation plan)
- Update admin featured image preview helpers to use `/view`
- Fix logout handler to redirect to homepage instead of login page
- Add E2E test scenario for logout redirect verification

## Testing

- All 64 unit tests passing
- Type checking: 0 errors  
- Build: Successful
- E2E: New logout redirect scenario added

## Fixes

- Closes: Article images broken; admin logout does not return to landing page

Made with [Cursor](https://cursor.com)